### PR TITLE
Corrected zkill links

### DIFF
--- a/src/controls/Overlays/KillFeed/Card.tsx
+++ b/src/controls/Overlays/KillFeed/Card.tsx
@@ -33,7 +33,7 @@ const KillCard: FC<KillProps> = ({ data }) => {
   );
 
   const onKillOpen = () => {
-    window.open(`https://zkillboard.com/kill/${data.killmail_id}`);
+    window.open(`https://zkillboard.com/kill/${data.killmail_id}/`);
   }
 
   return data && !data?.seen && (

--- a/src/controls/Overlays/System/index.tsx
+++ b/src/controls/Overlays/System/index.tsx
@@ -29,7 +29,7 @@ const SystemOverlay: FC<Props> = () => {
   }
 
   const onZKillboard = () => {
-    window.open(`https://zkillboard.com/system/${system.solarSystemID}`);
+    window.open(`https://zkillboard.com/system/${system.solarSystemID}/`);
   }
 
   const onDotlan = () => {


### PR DESCRIPTION
Added a / to the end of each of the links to zkillboard.com for killmails and systems.